### PR TITLE
fonts and settings updates

### DIFF
--- a/roles/fonts/defaults/main.yml
+++ b/roles/fonts/defaults/main.yml
@@ -1,3 +1,13 @@
 ---
 
 # Defaults file for the fonts role
+
+# see the list of fonts at https://github.com/powerline/fonts
+# the names must match the directory names for each font
+all_fonts:
+  - DejaVuSansMono
+  - FiraMono
+  - Hack
+  - RobotoMono
+  - SourceCodePro
+  - UbuntuMono

--- a/roles/fonts/tasks/main.yml
+++ b/roles/fonts/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Check for the presence of the 'fontconfig' package
+  ansible.builtin.stat:
+    path: /usr/lib/fontconfig
+  register: fontconfig
+
+- debug:
+    msg: "NOTE! The fontconfig package will now be installed, but this role won't work until the package is fully installed after a reboot."
+  when: fontconfig.stat.exists != true
+
 - name: Install fontconfig layered package
   community.general.rpm_ostree_pkg:
     name: fontconfig
@@ -7,34 +16,30 @@
     # apply_live: true
   become: yes
   become_method: sudo
+  when: fontconfig.stat.exists != true
 
 - name: Download powerline fonts git repository
   ansible.builtin.git:
     repo: 'https://github.com/powerline/fonts.git'
     dest: /tmp/fonts
 
-- name: Ensure all users have a local fonts directory
+- name: Ensure the user has a '~/.local/share/fonts' directory  
   ansible.builtin.file:
-    dest: "{{ item.homedir }}/.local/share/fonts"
+    dest: "{{ ansible_env.HOME }}/.local/share/fonts"
     state: directory
-    owner: "{{ item.user }}"
-    group: "{{ item.user }}"
-  with_items: "{{ all_users }}"
+    owner: "{{ ansible_env.USER }}"
+    group: "{{ ansible_env.USER }}"
 
-- name: copy fonts
-  ansible.builtin.command: cp -r /tmp/fonts/{{ item[1] }} {{ item[0].homedir }}/.local/share/fonts/
-  with_nested:
-   - "{{ all_users }}"
-   - "{{ all_fonts }}"
+- name: Copy fonts to the user's '~/.local/share/fonts' directory
+  ansible.builtin.command: cp -r /tmp/fonts/{{ item }} {{ ansible_env.HOME }}/.local/share/fonts/
+  loop: "{{ all_fonts }}"
   notify:
     Update font cache
 
 - name: Set fonts directory ownership
   ansible.builtin.file:
-    dest: "{{ item[0].homedir }}/.local/share/fonts/{{ item[1] }}"
+    dest: "{{ ansible_env.HOME }}/.local/share/fonts/{{ item }}"
     state: directory
-    owner: "{{ item[0].user }}"
-    group: "{{ item[0].user }}"
-  with_nested:
-   - "{{ all_users }}"
-   - "{{ all_fonts }}"
+    owner: "{{ ansible_env.USER }}"
+    group: "{{ ansible_env.USER }}"
+  loop: "{{ all_fonts }}"

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -1,12 +1,31 @@
 ---
 # tasks file for settings
 
+- name: Check for the presence of the 'python3-psutil' package
+  ansible.builtin.stat:
+    path:  /usr/share/doc/python3-psutil
+  register: psutil
+
+- debug:
+    msg: "NOTE! The python3-psutil package will now be installed, but this role won't work until the package is fully installed after a reboot."
+  when: psutil.stat.exists != true
+
+- name: Install python3-psutil layered package
+  community.general.rpm_ostree_pkg:
+    name: python3-psutil
+    state: present
+    # apply_live: true
+  become: yes
+  become_method: sudo
+  when: psutil.stat.exists != true
+
 - name: Apply desired settings via dconf
   community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
   loop: "{{ dconf_settings }}"
+  ignore_errors: true
 
 - name: Update the dconf database
   ansible.builtin.command: sudo dconf update


### PR DESCRIPTION
fonts - simplify the role to apply to only a single user at a time. Use data from 'gather_facts' to get user and homedir data.
settings - detail information about the needed packages. This situation will improve once the '--apply-live' feature becomes available in Ansible.