### PR TITLE
automatic method to reboot if new deployment ready

### DIFF
--- a/roles/layered_packages/tasks/main.yml
+++ b/roles/layered_packages/tasks/main.yml
@@ -27,3 +27,14 @@
 
 - debug:
     msg: "A reboot is required to complete installation / removal of these packages"
+
+- name: Query whether booted RPM-OSTree deployment is first deployment
+  shell: rpm-ostree status --json | jq -r .deployments[0].booted
+  register: booted
+
+- name: Reboot if new deployement is ready.
+  reboot:
+    reboot_timeout: 300
+  become: yes
+  when:
+    - booted.stdout == "false"


### PR DESCRIPTION
This should automatically reboot the system if it detects that it is not on the most recent deployment after installing/uninstalling applications